### PR TITLE
initial has-one attempt

### DIFF
--- a/models/position.go
+++ b/models/position.go
@@ -7,6 +7,7 @@ import (
 
 type Position struct {
 	gorm.Model
+	PlayerID uint
 	publicModels.Position
 	// Normalized   *Position `json:"normalized,omitempty"`
 	// Magnitude    float64   `json:"magnitude"`

--- a/models/rotation.go
+++ b/models/rotation.go
@@ -9,6 +9,7 @@ type Rotation struct {
 	gorm.Model
 	// Euler Rotation Annotation
 	// Yaw,Pitch,Roll
+	PlayerID uint
 	publicModels.Rotation
 
 	// EulerAngles *Vector3 `json:"eulerAngles"`

--- a/models/scale.go
+++ b/models/scale.go
@@ -7,6 +7,7 @@ import (
 
 type Scale struct {
 	gorm.Model
+	PlayerID uint
 	publicModels.Scale
 }
 


### PR DESCRIPTION
@Balugrizzly wanted to open a PR for this to facilitate communication

Is there more that needs to be done for this has-one relationship? I see that currently the playerWriter database call has db.Preload(clause.Associations), potentially this now needs to be in the child writers since that is now where the association is? And the Preload can be removed from the parent playerWriter?