### PR TITLE
update cosign-release version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
         with:
-          cosign-release: 'v1.11.0'
+          cosign-release: 'v1.11.1'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
Updated .github\workflows cosign-release to version v1.11.1